### PR TITLE
Tune node exporter scrape timing

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -118,7 +118,6 @@ services:
       - '--path.udev.data=/host/run/udev'
       - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc|run/user)($$|/)'
       - '--collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$$'
-      - '--collector.netdev.device-exclude=^(veth.*|docker.*|br-.*|lo)$$'
       - '--web.config.file=/etc/node-exporter/web-config.yml'
       - '--log.level=warn'
       - '--collector.disable-defaults'
@@ -126,7 +125,6 @@ services:
       - '--collector.filesystem'
       - '--collector.loadavg'
       - '--collector.meminfo'
-      - '--collector.netdev'
       - '--collector.time'
       - '--collector.uname'
     restart: unless-stopped

--- a/monitoring/TROUBLESHOOTING.md
+++ b/monitoring/TROUBLESHOOTING.md
@@ -18,15 +18,15 @@ node-exporter | time=2025-06-08T06:08:50.452Z level=ERROR source=http.go:219 msg
 
 **Решения:**
 
-#### 1. Увеличение таймаутов (уже применено)
+#### 1. Увеличение таймаутов
 ```yaml
 # prometheus.yml
 - job_name: 'node-exporter'
-  scrape_interval: 30s
-  scrape_timeout: 25s
+  scrape_interval: 60s
+  scrape_timeout: 55s
 ```
 
-#### 2. Ограничение коллекторов (уже применено)
+#### 2. Ограничение коллекторов
 ```yaml
 # docker-compose.yml
 command:
@@ -35,10 +35,11 @@ command:
   - '--collector.filesystem'
   - '--collector.loadavg'
   - '--collector.meminfo'
-  - '--collector.netdev'
   - '--collector.time'
   - '--collector.uname'
 ```
+Отключение `netdev` позволяет сократить объем сетевых метрик и снизить
+нагрузку на обработку, что также помогает избегать прерываний соединения.
 
 #### 3. Настройка логирования (уже применено)
 ```yaml
@@ -70,7 +71,7 @@ time curl -s http://localhost:9100/metrics > /dev/null
 
 1. **Увеличение ресурсов** контейнера node-exporter
 2. **Дальнейшее ограничение коллекторов**
-3. **Увеличение scrape_interval** до 60s
+3. **Увеличение scrape_interval** до 60s и `scrape_timeout` до 55s
 
 ## Другие проблемы
 

--- a/monitoring/prometheus/config/prometheus.yml
+++ b/monitoring/prometheus/config/prometheus.yml
@@ -38,8 +38,8 @@ scrape_configs:
   - job_name: 'node-exporter'
     static_configs:
       - targets: ['node-exporter:9100']
-    scrape_interval: 60s           # Увеличиваем интервал сбора метрик
-    scrape_timeout: 45s            # Увеличиваем таймаут сбора
+  scrape_interval: 60s           # Увеличиваем интервал сбора метрик
+  scrape_timeout: 55s            # Даем больше времени на отдачу метрик
     metrics_path: '/metrics'
     honor_labels: true             # Не перезаписывать метки
     scheme: http


### PR DESCRIPTION
## Summary
- increase Prometheus scrape_timeout for node-exporter to 55s
- disable the netdev collector to reduce metrics volume
- document the new timeout and collector config

## Testing
- `go test ./...`
- `docker-compose up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464d076eb88332834a344ab85ec531